### PR TITLE
Touchpad enhancements

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -1,9 +1,10 @@
 {
 	"id": "com.visiblink.newsz",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"vendor": "Shuswap",
 	"type": "web",
 	"main": "index.html",
 	"title": "NewsZ",
-	"icon": "icon.png"
+	"icon": "icon.png",
+	"uiRevision": "2"
 }


### PR DESCRIPTION
This PR makes a bunch of smallish changes that make NewsZ work well across all devices, with special enhancement for Touchpad:
- Launches full screen on Touchpad
- Shows a back button on Touchpad
- Adds a Share menu option that works via email on all devices
- Adds a Preferences menu option that goes to Preferences page

In order for Share to work, the app needs to keep track of each page that's loaded (which is dumb, but the webview doesn't have readable properties about its content)

Bumped the version number to 0.2.0